### PR TITLE
Add the 'get_work' part in the client example

### DIFF
--- a/example/client/main.go
+++ b/example/client/main.go
@@ -22,4 +22,6 @@ func main() {
 	}
 	worker = worker.SetAuthenticationKey(testresponse.String())
 	fmt.Println(worker.SessionAuthenticationKey)
+	testresponse, err = grequests.Post("http://127.0.0.1:3000/get_work", &grequests.RequestOptions{Params: map[string]string{"id": id, "sessionauthkey": worker.SessionAuthenticationKey}})
+	fmt.Println(testresponse.String())
 }


### PR DESCRIPTION
You forgot to use the `get_work` route, right?
Although, we don't add any `work`, it still gives a good example of how it is done.

Correct me, if I am wrong. :fearful: 
